### PR TITLE
Remove File Size Check and Add Visible File Info

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ categories = ["command-line-utilities"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[profile.release]
+opt-level = 3
+lto = true
+
 [dependencies]
 chrono = "0.4.23"
 clap = { version = "4.0.32", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bios_renamer_for_asus"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Brenden Davidson <davidson.brenden15@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bios_renamer_for_asus"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Brenden Davidson <davidson.brenden15@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,5 @@ opt-level = 3
 lto = true
 
 [dependencies]
-chrono = "0.4.23"
-clap = { version = "4.0.32", features = ["derive"] }
+chrono = "0.4.31"
+clap = { version = "4.4.8", features = ["derive"] }


### PR DESCRIPTION
Fixes #9 and adds the ability to print details about the selected file.

File details printout can be disabled with the new `--hide-details` flag.

File size checks have been removed since they only seem to apply to a specific, although incredibly common, set of AMD and Intel sockets from the last few years.